### PR TITLE
Disable visit filtering

### DIFF
--- a/app/screens/DomainDetails.js
+++ b/app/screens/DomainDetails.js
@@ -30,7 +30,6 @@ const prepareMessages = (visits) => {
   };
 
   return visits
-    .filter(visit => !!visit.title)
     .map((visit) => {
       const textParts = [
         visit.title,


### PR DESCRIPTION
For domains like twitter.com, when title was not recorded correctly, the currently open tab was filtered out as its visit did not have a title.